### PR TITLE
Rewrite in Java for Flink 1.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
-# flink-application
+# Flink Application
+
+This project provides a simple Java Flink 1.21 application. It reads from a table defined at runtime, converts it to a DataStream to replace the value of a specified field, and writes the modified stream to a Kafka topic.
+
+## Requirements
+
+- Java 8 or later
+- Maven
+- Kafka running and reachable
+
+## Build
+
+Use Maven to build the project:
+
+```bash
+mvn package
+```
+
+## Usage
+
+Run the application with the required arguments:
+
+```bash
+java -cp target/flink-application-0.1-SNAPSHOT.jar com.example.FlinkTableStreamer \
+  --source_ddl "<CREATE TABLE ...>" \
+  --sink_topic my-topic \
+  --field my_field \
+  --value new_value
+  [--bootstrap_servers localhost:9092]
+```
+
+The provided `CREATE TABLE` statement defines the source table. The application converts the table to a DataStream, replaces the selected field's value using the DataStream API, and writes the modified stream to the specified Kafka topic.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,31 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>flink-application</artifactId>
+    <version>0.1-SNAPSHOT</version>
+
+    <properties>
+        <flink.version>1.21.0</flink.version>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-streaming-java</artifactId>
+            <version>${flink.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-api-java-bridge</artifactId>
+            <version>${flink.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-connector-kafka</artifactId>
+            <version>${flink.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/main/java/com/example/FlinkTableStreamer.java
+++ b/src/main/java/com/example/FlinkTableStreamer.java
@@ -1,0 +1,97 @@
+package com.example;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import java.util.List;
+
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.types.Row;
+import org.apache.flink.api.common.functions.MapFunction;
+
+public class FlinkTableStreamer {
+
+    private static Map<String, String> parseArgs(String[] args) {
+        Map<String, String> map = new HashMap<>();
+        for (int i = 0; i < args.length; i++) {
+            if (args[i].startsWith("--") && i + 1 < args.length) {
+                String key = args[i].substring(2);
+                map.put(key, args[++i]);
+            }
+        }
+        return map;
+    }
+
+    private static String extractTableName(String ddl) {
+        Pattern p = Pattern.compile("CREATE\\s+TABLE\\s+`?(\\w+)`?", Pattern.CASE_INSENSITIVE);
+        Matcher m = p.matcher(ddl);
+        if (m.find()) {
+            return m.group(1);
+        }
+        throw new IllegalArgumentException("Could not extract table name from DDL");
+    }
+
+    public static void main(String[] args) throws Exception {
+        Map<String, String> params = parseArgs(args);
+        String sourceDDL = params.get("source_ddl");
+        String sinkTopic = params.get("sink_topic");
+        String field = params.get("field");
+        String value = params.get("value");
+        String bootstrap = params.getOrDefault("bootstrap_servers", "localhost:9092");
+
+        if (sourceDDL == null || sinkTopic == null || field == null || value == null) {
+            System.err.println("Required arguments: --source_ddl <ddl> --sink_topic <topic> --field <field> --value <value>");
+            return;
+        }
+
+        EnvironmentSettings settings = EnvironmentSettings
+                .newInstance()
+                .inStreamingMode()
+                .build();
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env, settings);
+
+        tEnv.executeSql(sourceDDL);
+        String sourceTable = extractTableName(sourceDDL);
+
+        String sinkDDL = String.format(
+                "CREATE TABLE sink_table LIKE %s (INCLUDING ALL) WITH (" +
+                        " 'connector' = 'kafka'," +
+                        " 'topic' = '%s'," +
+                        " 'properties.bootstrap.servers' = '%s'," +
+                        " 'format' = 'json'" +
+                        ")",
+                sourceTable, sinkTopic, bootstrap);
+        tEnv.executeSql(sinkDDL);
+
+        Table source = tEnv.from(sourceTable);
+        DataStream<Row> stream = tEnv.toDataStream(source);
+
+        List<String> names = source.getResolvedSchema().getColumnNames();
+        final int index = names.indexOf(field);
+        if (index < 0) {
+            throw new IllegalArgumentException("Field not found: " + field);
+        }
+
+        DataStream<Row> modifiedStream = stream.map(new MapFunction<Row, Row>() {
+            @Override
+            public Row map(Row r) {
+                Row copy = new Row(r.getArity());
+                for (int i = 0; i < r.getArity(); i++) {
+                    copy.setField(i, r.getField(i));
+                }
+                copy.setField(index, value);
+                return copy;
+            }
+        });
+
+        Table modified = tEnv.fromDataStream(modifiedStream).as(names.toArray(new String[0]));
+        modified.executeInsert("sink_table").await();
+    }
+}


### PR DESCRIPTION
## Summary
- replace PyFlink prototype with a Java application
- configure Maven project using Flink 1.21 and Kafka connector
- document build and execution steps in the README
- modify rows using the DataStream API before inserting into Kafka

## Testing
- `apt-get update` *(success)*
- `apt-get install -y maven` *(success)*
- `mvn -q -DskipTests package` *(fails: Network is unreachable while resolving Maven plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68589673bb7c8321b365eb3d33b46764