### PR TITLE
Add sink DDL support and strip AS SELECT

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ Run the application with the required arguments:
 
 ```bash
 java -cp target/flink-application-0.1-SNAPSHOT.jar com.example.FlinkTableStreamer \
-  --source_ddl "<CREATE TABLE ...>" \
-  --sink_topic my-topic \
+  --source_ddl "<CREATE TABLE ... AS SELECT ...>" \
+  --sink_ddl   "<CREATE TABLE ... AS SELECT ...>" \
   --field my_field \
   --value new_value
-  [--bootstrap_servers localhost:9092]
 ```
 
-The provided `CREATE TABLE` statement defines the source table. The application converts the table to a DataStream, replaces the selected field's value using the DataStream API, and writes the modified stream to the specified Kafka topic.
+
+The provided DDL strings may include a trailing `AS SELECT` clause. Only the `CREATE TABLE` portion is used to register the source and sink tables. The application converts the source table to a DataStream, replaces the selected field's value using the DataStream API, and writes the modified stream to the sink table.


### PR DESCRIPTION
## Summary
- add `sink_ddl` argument so sink table DDL can be provided
- strip trailing `AS SELECT` from both source and sink DDL
- insert into the extracted sink table
- document new arguments in README

## Testing
- `mvn -q -DskipTests package` *(fails: PluginResolutionException due to network)*

------
https://chatgpt.com/codex/tasks/task_e_68589b5ba8208321a8674e86eada804f